### PR TITLE
Fix non-accessible urls

### DIFF
--- a/functions/test-profile-details.js
+++ b/functions/test-profile-details.js
@@ -19,9 +19,7 @@ async function fetchCircleCIApiV2(endpoint) {
 }
 
 async function fetchCircleCIJobDetails(jobNumber) {
-	return fetchCircleCIApiV2(
-		`project/github/mui-org/material-ui/job/${jobNumber}`
-	);
+	return fetchCircleCIApiV2(`project/github/mui/material-ui/job/${jobNumber}`);
 }
 
 async function fetchCircleCIPipelineDetails(pipelineId) {

--- a/src/pages/Landing.js
+++ b/src/pages/Landing.js
@@ -355,7 +355,7 @@ function useRecentBuilds(filter) {
 }
 
 async function fetchRecentCircleCIBuilds(key, cursor = 0) {
-	const url = getCircleCIApiUrl("project/github/mui-org/material-ui", {
+	const url = getCircleCIApiUrl("project/github/mui/material-ui", {
 		filter: "completed",
 		limit: 100,
 		offset: 100 * cursor,

--- a/src/pages/SizeComparison.tsx
+++ b/src/pages/SizeComparison.tsx
@@ -75,7 +75,7 @@ async function fetchSizeSnapshotCircleCI(
 	buildNumber: number
 ): Promise<SizeSnapshot> {
 	const response = await fetch(
-		`https://circleci.com/api/v2/project/gh/mui-org/material-ui/${buildNumber}/artifacts`
+		`https://circleci.com/api/v2/project/gh/mui/material-ui/${buildNumber}/artifacts`
 	);
 	const body: CircleCIApiArtifacts = await response.json();
 
@@ -348,7 +348,7 @@ function Comparison({
 		const main: [string, Size][] = [];
 		const pages: [string, Size][] = [];
 		bundleKeys.forEach((bundle) => {
-			// current vs previous based off: https://github.com/mui-org/material-ui/blob/f1246e829f9c0fc9458ce951451f43c2f166c7d1/scripts/sizeSnapshot/loadComparison.js#L32
+			// current vs previous based off: https://github.com/mui/material-ui/blob/f1246e829f9c0fc9458ce951451f43c2f166c7d1/scripts/sizeSnapshot/loadComparison.js#L32
 			// if a bundle was added the change should be +inf
 			// if a bundle was removed the change should be -100%
 			const currentSize = targetSnapshot[bundle] || nullSnapshot;
@@ -441,7 +441,7 @@ function ComparisonErrorFallback({ prNumber }: { prNumber: number }) {
 	return (
 		<p>
 			Could not load comparison for{" "}
-			<Link href={`https://github.com/mui-org/material-ui/pull/${prNumber}`}>
+			<Link href={`https://github.com/mui/material-ui/pull/${prNumber}`}>
 				#{prNumber}
 			</Link>
 			. This can happen if the build in the CI job didn't finish yet.{" "}

--- a/src/pages/TestProfileAnalysis.tsx
+++ b/src/pages/TestProfileAnalysis.tsx
@@ -331,7 +331,7 @@ async function fetchCircleCIArtifactsInfos(
 	buildNumber: number
 ): Promise<Array<{ pretty_path: string; url: string }>> {
 	const apiEndpoint = `https://circleci.com/api/v1.1/`;
-	const url = `${apiEndpoint}project/github/mui-org/material-ui/${buildNumber}/artifacts`;
+	const url = `${apiEndpoint}project/github/mui/material-ui/${buildNumber}/artifacts`;
 
 	const response = await fetch(url);
 	const json = await response.json();


### PR DESCRIPTION
Github org got renamed over the weekend.
Left azure urls as they are as they don't seem to have updated. (Not sure where we use those either)